### PR TITLE
create separate build target that generates schems that should be run before app serve

### DIFF
--- a/packages/api/project.json
+++ b/packages/api/project.json
@@ -5,6 +5,10 @@
   "projectType": "application",
   "targets": {
     "build": {
+      "dependsOn": ["build-base", "^schema"],
+      "command": "echo 'Schemas and API are built'"
+    },
+    "build-base": {
       "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
@@ -34,26 +38,20 @@
             }
           }
         }
-      },
-      "dependsOn": [
-        {
-          "target": "schema",
-          "dependencies": true
-        }
-      ]
+      }
     },
     "serve": {
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",
       "options": {
-        "buildTarget": "api:build"
+        "buildTarget": "api:build-base"
       },
       "configurations": {
         "development": {
-          "buildTarget": "api:build:development"
+          "buildTarget": "api:build-base:development"
         },
         "production": {
-          "buildTarget": "api:build:production"
+          "buildTarget": "api:build-base:production"
         }
       }
     }

--- a/packages/bar/project.json
+++ b/packages/bar/project.json
@@ -6,16 +6,22 @@
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{options.outputPath}"
+      ],
       "defaultConfiguration": "production",
       "options": {
         "platform": "node",
         "outputPath": "dist/packages/bar",
-        "format": ["cjs"],
+        "format": [
+          "cjs"
+        ],
         "bundle": false,
         "main": "packages/bar/src/main.ts",
         "tsConfig": "packages/bar/tsconfig.app.json",
-        "assets": ["packages/bar/src/assets"],
+        "assets": [
+          "packages/bar/src/assets"
+        ],
         "generatePackageJson": true,
         "esbuildOptions": {
           "sourcemap": true,
@@ -26,10 +32,10 @@
       }
     },
     "schema": {
-      "watch": false,
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",
       "options": {
+        "watch": false,
         "buildTarget": "bar:build"
       }
     }

--- a/packages/bar/src/main.ts
+++ b/packages/bar/src/main.ts
@@ -1,8 +1,9 @@
-import { writeFileSync } from 'fs';
+import { writeFileSync, mkdirSync } from 'fs';
 import * as process from 'process';
 
 console.log('generating bar schema at generated/bar/api.txt');
 
-writeFileSync('generated/bar/api.txt', `I am ${process.env.APP_NAME}`, {encoding: 'utf-8'})
+mkdirSync('generated/bar', { recursive: true });
+writeFileSync('generated/bar/api.txt', `5 I am ${process.env.APP_NAME}`, { encoding: 'utf-8' })
 
 process.exit();

--- a/packages/foo/project.json
+++ b/packages/foo/project.json
@@ -6,16 +6,22 @@
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{options.outputPath}"
+      ],
       "defaultConfiguration": "production",
       "options": {
         "platform": "node",
         "outputPath": "dist/packages/foo",
-        "format": ["cjs"],
+        "format": [
+          "cjs"
+        ],
         "bundle": false,
         "main": "packages/foo/src/main.ts",
         "tsConfig": "packages/foo/tsconfig.app.json",
-        "assets": ["packages/foo/src/assets"],
+        "assets": [
+          "packages/foo/src/assets"
+        ],
         "generatePackageJson": true,
         "esbuildOptions": {
           "sourcemap": true,
@@ -26,9 +32,9 @@
       }
     },
     "schema": {
-      "watch": false,
       "executor": "@nx/js:node",
       "options": {
+        "watch": false,
         "buildTarget": "foo:build"
       }
     }

--- a/packages/foo/src/main.ts
+++ b/packages/foo/src/main.ts
@@ -1,8 +1,10 @@
-import {writeFileSync} from 'fs';
+import { writeFileSync, mkdirSync } from 'fs';
 import process from 'process';
 
 console.log('generating foo schema at generated/foo/api.txt');
 
-writeFileSync('generated/foo/api.txt', `I am ${process.env.APP_NAME}`, {encoding: 'utf-8'})
+console.log('>>> bar', process.env.APP_NAME);
+mkdirSync('generated/foo/', { recursive: true });
+writeFileSync('generated/foo/api.txt', `I am ${process.env.APP_NAME}`, { encoding: 'utf-8' })
 
 process.exit();


### PR DESCRIPTION
This PR separates "build with schemas" and "build app only" into two tasks, as a workaround  to https://github.com/nrwl/nx/issues/17128.

The full production build (with schemas) is the same as before:

```
nx build api
```

The app-only build is created as `build-base`, and does not re-generate the schema files.

```
# skips schemas
nx build-base 
```

And now `serve` points to `build-base`, which prevents schemas from generating again, thus running `api` will not clobber the generated files (`generated/foo/api.txt` and `generated/bar/api.txt`).

---

## Notes

The problem with the previous setup when it comes to the the refactored `@nx/js:node` executor is that the executor now correctly runs all dependency tasks (e.g. the `schema` tasks). _However_, this has the side-effect of the `.env` file for the initial app being loaded first, which prevents other `.env` files from overwriting the same environment variables.

In this example repo's case, the `APP_NAME` being loaded from `api` app means that the other `APP_NAME` values from `foo` and `bar` aren't used as `dotenv` does not allow overrides.



